### PR TITLE
Fix span behavior

### DIFF
--- a/src/Model/Style.php
+++ b/src/Model/Style.php
@@ -63,16 +63,22 @@ final class Style implements Stringable
 
     public function patch(Style $other): self
     {
-        $this->fg = $other->fg ?? $this->fg;
-        $this->bg = $other->bg ?? $this->bg;
-        $this->underline = $other->underline ?? $this->underline;
 
-        $this->addModifiers &= ~$other->subModifiers;
-        $this->addModifiers |= $other->addModifiers;
-        $this->subModifiers &= ~$other->addModifiers;
-        $this->subModifiers |= $other->subModifiers;
+        $addModifiers = $this->addModifiers;
+        $addModifiers &= ~$other->subModifiers;
+        $addModifiers |= $other->addModifiers;
 
-        return $this;
+        $subModifiers = $this->subModifiers;
+        $subModifiers &= ~$other->addModifiers;
+        $subModifiers |= $other->subModifiers;
+
+        return new self(
+            fg: $other->fg ?? $this->fg,
+            bg: $other->bg ?? $this->bg,
+            underline: $other->underline ?? $this->underline,
+            addModifiers:$addModifiers,
+            subModifiers: $subModifiers,
+        );
     }
 
     /**

--- a/src/Model/Widget/Span.php
+++ b/src/Model/Widget/Span.php
@@ -30,7 +30,7 @@ final class Span implements Stringable
 
     public function patchStyle(Style $style): void
     {
-        $this->style->patch($style);
+        $this->style = $this->style->patch($style);
     }
 
     /**
@@ -41,7 +41,7 @@ final class Span implements Stringable
         return array_map(function (string $grapheme) use ($baseStyle) {
             return new StyledGrapheme(
                 symbol: $grapheme,
-                style: $this->style->patch($baseStyle),
+                style: $baseStyle->patch($this->style),
             );
         }, mb_str_split($this->content));
     }

--- a/tests/Unit/Model/SpanTest.php
+++ b/tests/Unit/Model/SpanTest.php
@@ -13,13 +13,15 @@ class SpanTest extends TestCase
 {
     public function testToStyledGraphemes(): void
     {
-        $baseStyle = Style::default()->fg(AnsiColor::Red);
         $span = Span::styled('Hello', Style::default()->fg(AnsiColor::Blue));
 
+        $baseStyle = Style::default()->fg(AnsiColor::Red);
         $styledGraphemes = $span->toStyledGraphemes($baseStyle);
-        for ($i = 0; $i < count($styledGraphemes); $i++) {
-            $grapheme = $styledGraphemes[$i];
-            self::assertEquals(AnsiColor::Red, $grapheme->style->fg);
+
+        self::assertCount(5, $styledGraphemes);
+
+        foreach ($styledGraphemes as $i => $grapheme) {
+            self::assertEquals(AnsiColor::Blue, $grapheme->style->fg, );
             self::assertEquals($span->content[$i], $grapheme->symbol);
         }
 


### PR DESCRIPTION
Maintain Ratatui's behavior.

I think the problem is rather that Rust implciitly Copys the style, where as in PHP it is by reference. Here I changed the behavior to make `Style#patch` immutable.  